### PR TITLE
Fixed estimator topic paths to be relative.

### DIFF
--- a/src/estimator_base.cpp
+++ b/src/estimator_base.cpp
@@ -7,10 +7,10 @@ estimator_base::estimator_base():
     nh_(ros::NodeHandle()),
     nh_private_(ros::NodeHandle("~"))
 {
-    nh_private_.param<std::string>("gps_topic", gps_topic_, "/gps/data");
-    nh_private_.param<std::string>("imu_topic", imu_topic_, "/imu/data");
-    nh_private_.param<std::string>("baro_topic", baro_topic_, "/baro/alt");
-    nh_private_.param<std::string>("airspeed_topic", airspeed_topic_, "/airspeed/data");
+    nh_private_.param<std::string>("gps_topic", gps_topic_, "gps/data");
+    nh_private_.param<std::string>("imu_topic", imu_topic_, "imu/data");
+    nh_private_.param<std::string>("baro_topic", baro_topic_, "baro/alt");
+    nh_private_.param<std::string>("airspeed_topic", airspeed_topic_, "airspeed/data");
     nh_private_.param<double>("update_rate", update_rate_, 100.0);
     params_.Ts = 1.0f/update_rate_;
     params_.gravity = 9.8;


### PR DESCRIPTION
Allows for proper namespacing when spawning multiple MAVs from a launch file.