### PR TITLE
Added lpf and gating on altitude

### DIFF
--- a/rosplane/include/estimator_base.h
+++ b/rosplane/include/estimator_base.h
@@ -37,7 +37,7 @@ protected:
         float accel_x;
         float accel_y;
         float accel_z;
-        float baro_alt;
+        float static_pres;
         float diff_pres;
         bool gps_new;
         float gps_n;
@@ -106,8 +106,9 @@ private:
     double                          init_lat_;	/**< Initial latitude in degrees */
     double                          init_lon_;	/**< Initial longitude in degrees */
     float                           init_alt_;	/**< Initial altitude in meters above MSL  */
-//    bool                            _baro_init;
-//    float                           _init_static; /**< Initial static pressure (mbar)  */
+    bool                            _baro_init;
+    float                           _init_static; /**< Initial static pressure (mbar)  */
+    int                             _baro_count; /**< Used to grab the first set of baro measurements */
 
     struct params_s                 params_;
     struct input_s                  input_;

--- a/rosplane/include/estimator_example.h
+++ b/rosplane/include/estimator_example.h
@@ -32,7 +32,7 @@ private:
     float lpf_gyro_x;
     float lpf_gyro_y;
     float lpf_gyro_z;
-//    float lpf_static;
+    float lpf_static;
     float lpf_diff;
     float lpf_accel_x;
     float lpf_accel_y;

--- a/rosplane/src/estimator_base.cpp
+++ b/rosplane/src/estimator_base.cpp
@@ -27,6 +27,8 @@ estimator_base::estimator_base():
     airspeed_sub_ = nh_.subscribe(airspeed_topic_, 10, &estimator_base::airspeedCallback, this);
     update_timer_ = nh_.createTimer(ros::Duration(1.0/update_rate_), &estimator_base::update, this);
     vehicle_state_pub_ = nh_.advertise<rosplane_msgs::State>("state",10);
+    _init_static = 0;
+    _baro_count = 0;
 }
 
 void estimator_base::update(const ros::TimerEvent&)
@@ -101,7 +103,36 @@ void estimator_base::imuCallback(const sensor_msgs::Imu &msg)
 
 void estimator_base::baroAltCallback(const rosflight_msgs::Barometer &msg)
 {
-    input_.baro_alt = -msg.altitude;
+
+    if(!_baro_init)
+    {
+        if(_baro_count < 100)
+        {
+            _init_static += msg.pressure;
+            input_.static_pres = 0;
+            _baro_count += 1;
+        }
+        else
+        {
+            _init_static = _init_static/100;
+            _baro_init = true;
+        }
+    }
+    else
+    {
+        float static_pres_old = input_.static_pres;
+        input_.static_pres = -msg.pressure + _init_static;
+
+        float gate_gain = 1.35*params_.rho*params_.gravity;
+        if(input_.static_pres < static_pres_old - gate_gain)
+        {
+            input_.static_pres = static_pres_old - gate_gain;
+        }
+        else if(input_.static_pres > static_pres_old + gate_gain)
+        {
+            input_.static_pres = static_pres_old + gate_gain;
+        }
+    }
 }
 
 void estimator_base::airspeedCallback(const rosflight_msgs::Airspeed &msg)

--- a/rosplane/src/estimator_example.cpp
+++ b/rosplane/src/estimator_example.cpp
@@ -81,10 +81,8 @@ void estimator_example::estimate(const params_s &params, const input_s &input, o
     float rhat = lpf_gyro_z;
 
     // low pass filter static pressure sensor and invert to esimate altitude
-    //lpf_static = alpha1*lpf_static + (1-alpha1)*input.static_pres;
-    //float hhat = lpf_static/params.rho/params.gravity;
-    // !!! normally we would low pass filter the static pressure but the NAZE already does that
-    float hhat = input.baro_alt;
+    lpf_static = alpha1*lpf_static + (1-alpha1)*input.static_pres;
+    float hhat = lpf_static/params.rho/params.gravity;
 
     // low pass filter diff pressure sensor and invert to extimate Va
     lpf_diff = alpha1*lpf_diff + (1-alpha1)*input.diff_pres;


### PR DESCRIPTION
The stuff in the estimator base is used for outlier rejection. It also collects the first 100 measurements and then averages them to create the estimate the pressure at an altitude of "0".