### PR TITLE
Stop estimator when disarmed

### DIFF
--- a/rosplane/include/estimator_base.h
+++ b/rosplane/include/estimator_base.h
@@ -15,6 +15,7 @@
 #include <sensor_msgs/Imu.h>
 #include <rosflight_msgs/Barometer.h>
 #include <rosflight_msgs/Airspeed.h>
+#include <rosflight_msgs/Status.h>
 #include <math.h>
 #include <Eigen/Eigen>
 
@@ -45,6 +46,7 @@ protected:
         float gps_h;
         float gps_Vg;
         float gps_course;
+        bool status_armed;
     };
 
     struct output_s{
@@ -87,12 +89,14 @@ private:
     ros::Subscriber imu_sub_;
     ros::Subscriber baro_sub_;
     ros::Subscriber airspeed_sub_;
+    ros::Subscriber status_sub_;
 
     void update(const ros::TimerEvent &);
     void gpsCallback(const rosflight_msgs::GPS &msg);
     void imuCallback(const sensor_msgs::Imu &msg);
     void baroAltCallback(const rosflight_msgs::Barometer &msg);
     void airspeedCallback(const rosflight_msgs::Airspeed &msg);
+    void statusCallback(const rosflight_msgs::Status &msg);
 
     double update_rate_;
     ros::Timer update_timer_;
@@ -100,6 +104,7 @@ private:
     std::string imu_topic_;
     std::string baro_topic_;
     std::string airspeed_topic_;
+    std::string status_topic_;
 
     bool                            gps_new_;
     bool                            gps_init_;

--- a/rosplane/src/estimator_base.cpp
+++ b/rosplane/src/estimator_base.cpp
@@ -11,6 +11,7 @@ estimator_base::estimator_base():
     nh_private_.param<std::string>("imu_topic", imu_topic_, "imu/data");
     nh_private_.param<std::string>("baro_topic", baro_topic_, "baro");
     nh_private_.param<std::string>("airspeed_topic", airspeed_topic_, "airspeed");
+    nh_private_.param<std::string>("status_topic", status_topic_, "status");
     nh_private_.param<double>("update_rate", update_rate_, 100.0);
     params_.Ts = 1.0f/update_rate_;
     params_.gravity = 9.8;
@@ -25,6 +26,7 @@ estimator_base::estimator_base():
     imu_sub_ = nh_.subscribe(imu_topic_, 10, &estimator_base::imuCallback, this);
     baro_sub_ = nh_.subscribe(baro_topic_, 10, &estimator_base::baroAltCallback, this);
     airspeed_sub_ = nh_.subscribe(airspeed_topic_, 10, &estimator_base::airspeedCallback, this);
+    status_sub_ = nh_.subscribe(status_topic_, 1, &estimator_base::statusCallback, this);
     update_timer_ = nh_.createTimer(ros::Duration(1.0/update_rate_), &estimator_base::update, this);
     vehicle_state_pub_ = nh_.advertise<rosplane_msgs::State>("state",10);
     _init_static = 0;
@@ -34,7 +36,10 @@ estimator_base::estimator_base():
 void estimator_base::update(const ros::TimerEvent&)
 {
     struct output_s output;
-    estimate(params_, input_, output);
+    if(input_.status_armed)
+    {
+        estimate(params_, input_, output);
+    }
     input_.gps_new = false;
 
     rosplane_msgs::State msg;
@@ -147,6 +152,11 @@ void estimator_base::baroAltCallback(const rosflight_msgs::Barometer &msg)
 void estimator_base::airspeedCallback(const rosflight_msgs::Airspeed &msg)
 {
     input_.diff_pres = msg.differential_pressure;
+}
+
+void estimator_base::statusCallback(const rosflight_msgs::Status &msg)
+{
+    input_.status_armed = msg.armed;
 }
 
 } //end namespace


### PR DESCRIPTION
I tried to keep it as simple as possible. The disarmed subscription populates a class variable that can then be used to stop or start anything you want. Right now, only the estimator stops, and all of its message fields go to zero.