### PR TITLE
Added gating for outlier rejection on diff_pressure measurements

### DIFF
--- a/rosplane/src/estimator_base.cpp
+++ b/rosplane/src/estimator_base.cpp
@@ -146,7 +146,18 @@ void estimator_base::baroAltCallback(const rosflight_msgs::Barometer &msg)
 
 void estimator_base::airspeedCallback(const rosflight_msgs::Airspeed &msg)
 {
+    float diff_pres_old = input_.diff_pres;
     input_.diff_pres = msg.differential_pressure;
+
+    float gate_gain = pow(10,2)*params_.rho/2.0;
+    if(input_.diff_pres < diff_pres_old - gate_gain)
+    {
+        input_.diff_pres = diff_pres_old - gate_gain;
+    }
+    else if(input_.diff_pres > diff_pres_old + gate_gain)
+    {
+        input_.diff_pres = diff_pres_old + gate_gain;
+    }
 }
 
 } //end namespace


### PR DESCRIPTION
The airspeed sensor was returning a very negative differential pressure measurement sometimes. This would cause the airspeed to go really negative for a second. This will hopefully reject those outlier measurements. 

![diff_pres](https://user-images.githubusercontent.com/3312740/28472832-6172752e-6dff-11e7-8aa6-1eaa11513f2c.jpg)
