### PR TITLE
Warning-free catkin_make builds

### DIFF
--- a/rosplane/CMakeLists.txt
+++ b/rosplane/CMakeLists.txt
@@ -1,16 +1,24 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rosplane)
 
+set(CMAKE_CXX_STANDARD 11)
+if (NOT CMAKE_BUILD_TYPE)
+    # Options: Debug, Release, MinSizeRel, RelWithDebInfo
+    message(STATUS "No build type selected, default to Release")
+    set(CMAKE_BUILD_TYPE "Release")
+endif()
+
+set(CMAKE_CXX_FLAGS "-fopenmp")
+
 find_package(catkin REQUIRED COMPONENTS
-  rosflight_msgs
-  rosplane_msgs
   roscpp
   rospy
-  cmake_modules
+  rosflight_msgs
+  rosplane_msgs
   dynamic_reconfigure
   sensor_msgs
 )
-find_package(Eigen REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 ################################################
 ## Declare ROS dynamic reconfigure parameters ##
@@ -35,87 +43,46 @@ generate_dynamic_reconfigure_options(
 catkin_package(
   INCLUDE_DIRS include
 #  LIBRARIES
-  CATKIN_DEPENDS rosflight_msgs rosplane_msgs roscpp rospy
+  CATKIN_DEPENDS roscpp rospy rosflight_msgs rosplane_msgs
 #  DEPENDS system_lib
 )
-add_definitions(-std=c++11)
 
-include_directories(include)
-include_directories(
-  ${catkin_INCLUDE_DIRS}
-  ${EIGEN_INCLUDE_DIRS}
-)
+include_directories(include ${catkin_INCLUDE_DIRS} ${EIGEN3_INCLUDE_DIRS})
 
 ## Declare a C++ executable
 add_executable(rosplane_controller
             src/controller_base.cpp
-            src/controller_example.cpp
-            include/controller_base.h
-            include/controller_example.h
-)
-
-## Add cmake target dependencies of the executable
-## same as for the library above
-add_dependencies(rosplane_controller ${PROJECT_NAME}_gencfg)
-add_dependencies(rosplane_controller ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-## Specify libraries to link a library or executable target against
-target_link_libraries(rosplane_controller
-  ${catkin_LIBRARIES}
-)
+            src/controller_example.cpp)
+add_dependencies(rosplane_controller ${catkin_EXPORTED_TARGETS} ${PROJECT_NAME}_gencfg)
+target_link_libraries(rosplane_controller ${catkin_LIBRARIES})
 
 
 ## Declare a C++ executable
 add_executable(rosplane_estimator
             src/estimator_base.cpp
-            src/estimator_example.cpp
-            include/estimator_base.h
-            include/estimator_example.h
-)
+            src/estimator_example.cpp)
+add_dependencies(rosplane_estimator ${catkin_EXPORTED_TARGETS})
+target_link_libraries(rosplane_estimator ${catkin_LIBRARIES})
 
-## Add cmake target dependencies of the executable
-## same as for the library above
-add_dependencies(rosplane_estimator ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
-## Specify libraries to link a library or executable target against
-target_link_libraries(rosplane_estimator
-  ${catkin_LIBRARIES}
-)
-
+## Declare a C++ executable
 add_executable(rosplane_path_follower
             src/path_follower_example.cpp
             src/path_follower_base.cpp)
+add_dependencies(rosplane_path_follower ${catkin_EXPORTED_TARGETS} ${PROJECT_NAME}_gencfg)
+target_link_libraries(rosplane_path_follower ${catkin_LIBRARIES})
 
-add_dependencies(rosplane_path_follower ${PROJECT_NAME}_gencfg)
-add_dependencies(rosplane_path_follower ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-target_link_libraries(rosplane_path_follower
-  ${catkin_LIBRARIES}
-)
 
 ## Declare a C++ executable
 add_executable(rosplane_path_manager
             src/path_manager_base.cpp
-            src/path_manager_example.cpp
-)
-## Add cmake target dependencies of the executable
-## same as for the library above
-add_dependencies(rosplane_path_manager ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+            src/path_manager_example.cpp)
+add_dependencies(rosplane_path_manager ${catkin_EXPORTED_TARGETS})
+target_link_libraries(rosplane_path_manager ${catkin_LIBRARIES})
 
-## Specify libraries to link a library or executable target against
-target_link_libraries(rosplane_path_manager
-  ${catkin_LIBRARIES}
-)
 
 ## Declare a C++ executable
 add_executable(rosplane_path_planner
-            src/path_planner.cpp
-)
-## Add cmake target dependencies of the executable
-## same as for the library above
-add_dependencies(rosplane_path_planner ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-## Specify libraries to link a library or executable target against
-target_link_libraries(rosplane_path_planner
-  ${catkin_LIBRARIES}
-)
+            src/path_planner.cpp)
+add_dependencies(rosplane_path_planner ${catkin_EXPORTED_TARGETS})
+target_link_libraries(rosplane_path_planner ${catkin_LIBRARIES})

--- a/rosplane_sim/CMakeLists.txt
+++ b/rosplane_sim/CMakeLists.txt
@@ -1,21 +1,29 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rosplane_sim)
 
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+set(CMAKE_CXX_STANDARD 11)
+if (NOT CMAKE_BUILD_TYPE)
+    # Options: Debug, Release, MinSizeRel, RelWithDebInfo
+    message(STATUS "No build type selected, default to Release")
+    set(CMAKE_BUILD_TYPE "Release")
+endif()
+
+set(CMAKE_CXX_FLAGS "-fopenmp")
 
 # To enable assertions when compiled in release mode.
 add_definitions(-DROS_ASSERT_ENABLED)
 
 find_package(catkin REQUIRED COMPONENTS
   roscpp
-  gazebo_plugins
-  gazebo_ros
   geometry_msgs
   rosplane_msgs
+  gazebo_plugins
+  gazebo_ros
 )
 
 find_package(Eigen3 REQUIRED)
 find_package(gazebo REQUIRED)
+link_directories(${GAZEBO_LIBRARY_DIRS})
 
 catkin_package(
   INCLUDE_DIRS include
@@ -23,21 +31,17 @@ catkin_package(
   DEPENDS EIGEN3 GAZEBO
 )
 
-include_directories(include)
 include_directories(
+  include
   ${catkin_INCLUDE_DIRS}
-  ${Eigen_INCLUDE_DIRS}
+  ${EIGEN3_INCLUDE_DIRS}
   ${GAZEBO_INCLUDE_DIRS}
-  ${SDFormat_INCLUDE_DIRS}
 )
-link_directories(${GAZEBO_LIBRARY_DIRS})
 
-add_library(aircraft_truth_plugin
-src/aircraft_truth.cpp)
+add_library(aircraft_truth_plugin src/aircraft_truth.cpp)
 target_link_libraries(aircraft_truth_plugin ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES})
-add_dependencies(aircraft_truth_plugin ${catkin_EXPORTED_TARGETS} rosflight_msgs_generate_messages_cpp)
+add_dependencies(aircraft_truth_plugin ${catkin_EXPORTED_TARGETS})
 
-add_library(aircraft_forces_and_moments_plugin
-  src/aircraft_forces_and_moments.cpp)
+add_library(aircraft_forces_and_moments_plugin src/aircraft_forces_and_moments.cpp)
 target_link_libraries(aircraft_forces_and_moments_plugin ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES})
-add_dependencies(aircraft_forces_and_moments_plugin ${catkin_EXPORTED_TARGETS} rosflight_msgs_generate_messages_cpp)
+add_dependencies(aircraft_forces_and_moments_plugin ${catkin_EXPORTED_TARGETS})


### PR DESCRIPTION
- Cleaned up `CMakeLists.txt` to make them more consistent with `roscopter` and `rosflight_plugins`.
- Fixed some `Eigen` build issues that caused CMake warnings to show when running `catkin_make`.
- Default build is in `Release` -- can be changed to debug with

    ```
    $ catkin_make -DCMAKE_BUILD_TYPE=Debug
    ```
- Uses `C++11` as the standard