### PR TITLE
Added outlier rejection to baro calibration

### DIFF
--- a/rosplane/include/estimator_base.h
+++ b/rosplane/include/estimator_base.h
@@ -115,6 +115,7 @@ private:
     bool                            _baro_init;
     float                           _init_static; /**< Initial static pressure (mbar)  */
     int                             _baro_count; /**< Used to grab the first set of baro measurements */
+    std::vector<float>              _init_static_vector; /**< Used to calibrate baro */
 
     struct params_s                 params_;
     struct input_s                  input_;


### PR DESCRIPTION
When outlier measurements are detected by the barometer during the first second of calibration, it will automatically recalibrate the baro until it gets a good calibration. A ROS warning message will appear.