### PR TITLE
Add standard library include

### DIFF
--- a/rosplane/include/estimator_base.h
+++ b/rosplane/include/estimator_base.h
@@ -22,8 +22,6 @@
 
 #define EARTH_RADIUS 6378145.0f
 
-
-
 namespace rosplane
 {
 

--- a/rosplane/include/estimator_base.h
+++ b/rosplane/include/estimator_base.h
@@ -9,9 +9,6 @@
 #ifndef ESTIMATOR_BASE_H
 #define ESTIMATOR_BASE_H
 
-using namespace std;
-
-
 #include <ros/ros.h>
 #include <rosplane_msgs/State.h>
 #include <rosflight_msgs/GPS.h>

--- a/rosplane/include/estimator_base.h
+++ b/rosplane/include/estimator_base.h
@@ -9,6 +9,9 @@
 #ifndef ESTIMATOR_BASE_H
 #define ESTIMATOR_BASE_H
 
+using namespace std;
+
+
 #include <ros/ros.h>
 #include <rosplane_msgs/State.h>
 #include <rosflight_msgs/GPS.h>
@@ -18,8 +21,11 @@
 #include <rosflight_msgs/Status.h>
 #include <math.h>
 #include <Eigen/Eigen>
+#include <numeric>
 
 #define EARTH_RADIUS 6378145.0f
+
+
 
 namespace rosplane
 {


### PR DESCRIPTION
This addition allows rosplane to compile successfully in Arch linux and Fedora. A function from numeric was being used without numeric being included.