### PR TITLE
Delta race condition fix

### DIFF
--- a/rosplane_sim/src/aircraft_forces_and_moments.cpp
+++ b/rosplane_sim/src/aircraft_forces_and_moments.cpp
@@ -159,6 +159,12 @@ void AircraftForcesAndMoments::Load(physics::ModelPtr _model, sdf::ElementPtr _s
   wind_.E = 0.0;
   wind_.D = 0.0;
 
+  //initialize deltas
+  delta_.t = 0.0;
+  delta_.e = 0.0;
+  delta_.a = 0.0;
+  delta_.r = 0.0;
+
   // Connect the update function to the simulation
   updateConnection_ = event::Events::ConnectWorldUpdateBegin(boost::bind(&AircraftForcesAndMoments::OnUpdate, this, _1));
 


### PR DESCRIPTION
The forces and moments file didn't have delta_.t, delta_.e, delta_.a, delta_.r initialized. This caused fatal errors if the command callback wasn't called before UpdateForcesAndMoments executed. The fix is to initialize those values to 0 in the load function.