### PR TITLE
Issue 70 - Compatibility with ROSflight GNSS Messages

### DIFF
--- a/rosplane/include/estimator_base.h
+++ b/rosplane/include/estimator_base.h
@@ -11,7 +11,7 @@
 
 #include <ros/ros.h>
 #include <rosplane_msgs/State.h>
-#include <rosflight_msgs/GPS.h>
+#include <sensor_msgs/NavSatFix.h>
 #include <sensor_msgs/Imu.h>
 #include <rosflight_msgs/Barometer.h>
 #include <rosflight_msgs/Airspeed.h>
@@ -98,7 +98,7 @@ private:
   ros::Subscriber status_sub_;
 
   void update(const ros::TimerEvent &);
-  void gpsCallback(const rosflight_msgs::GPS &msg);
+  void gpsCallback(const sensor_msgs::NavSatFix &msg);
   void imuCallback(const sensor_msgs::Imu &msg);
   void baroAltCallback(const rosflight_msgs::Barometer &msg);
   void airspeedCallback(const rosflight_msgs::Airspeed &msg);

--- a/rosplane/include/estimator_base.h
+++ b/rosplane/include/estimator_base.h
@@ -13,6 +13,7 @@
 #include <rosplane_msgs/State.h>
 #include <sensor_msgs/NavSatFix.h>
 #include <sensor_msgs/Imu.h>
+#include <geometry_msgs/TwistStamped.h>
 #include <rosflight_msgs/Barometer.h>
 #include <rosflight_msgs/Airspeed.h>
 #include <rosflight_msgs/Status.h>
@@ -91,14 +92,16 @@ private:
   ros::NodeHandle nh_;
   ros::NodeHandle nh_private_;
   ros::Publisher vehicle_state_pub_;
-  ros::Subscriber gps_sub_;
+  ros::Subscriber nav_sat_fix_sub_;
+  ros::Subscriber twist_stamped_sub_; //used in conjunction with the nav_sat_fix_sub_
   ros::Subscriber imu_sub_;
   ros::Subscriber baro_sub_;
   ros::Subscriber airspeed_sub_;
   ros::Subscriber status_sub_;
 
   void update(const ros::TimerEvent &);
-  void gpsCallback(const sensor_msgs::NavSatFix &msg);
+  void navSatFixCallback(const sensor_msgs::NavSatFix &msg);
+  void twistStampedCallback(const geometry_msgs::TwistStamped &msg);
   void imuCallback(const sensor_msgs::Imu &msg);
   void baroAltCallback(const rosflight_msgs::Barometer &msg);
   void airspeedCallback(const rosflight_msgs::Airspeed &msg);
@@ -107,6 +110,7 @@ private:
   double update_rate_;
   ros::Timer update_timer_;
   std::string gps_topic_;
+  std::string vel_topic_;
   std::string imu_topic_;
   std::string baro_topic_;
   std::string airspeed_topic_;

--- a/rosplane/include/estimator_base.h
+++ b/rosplane/include/estimator_base.h
@@ -92,16 +92,16 @@ private:
   ros::NodeHandle nh_;
   ros::NodeHandle nh_private_;
   ros::Publisher vehicle_state_pub_;
-  ros::Subscriber nav_sat_fix_sub_;
-  ros::Subscriber twist_stamped_sub_; //used in conjunction with the nav_sat_fix_sub_
+  ros::Subscriber gnss_fix_sub_;
+  ros::Subscriber gnss_vel_sub_; //used in conjunction with the gnss_fix_sub_
   ros::Subscriber imu_sub_;
   ros::Subscriber baro_sub_;
   ros::Subscriber airspeed_sub_;
   ros::Subscriber status_sub_;
 
   void update(const ros::TimerEvent &);
-  void navSatFixCallback(const sensor_msgs::NavSatFix &msg);
-  void twistStampedCallback(const geometry_msgs::TwistStamped &msg);
+  void gnssFixCallback(const sensor_msgs::NavSatFix &msg);
+  void gnssVelCallback(const geometry_msgs::TwistStamped &msg);
   void imuCallback(const sensor_msgs::Imu &msg);
   void baroAltCallback(const rosflight_msgs::Barometer &msg);
   void airspeedCallback(const rosflight_msgs::Airspeed &msg);
@@ -109,8 +109,8 @@ private:
 
   double update_rate_;
   ros::Timer update_timer_;
-  std::string gps_topic_;
-  std::string vel_topic_;
+  std::string gnss_fix_topic_;
+  std::string gnss_vel_topic_;
   std::string imu_topic_;
   std::string baro_topic_;
   std::string airspeed_topic_;

--- a/rosplane/src/estimator_base.cpp
+++ b/rosplane/src/estimator_base.cpp
@@ -9,8 +9,8 @@ estimator_base::estimator_base():
   nh_(ros::NodeHandle()),
   nh_private_(ros::NodeHandle("~"))
 {
-  nh_private_.param<std::string>("gps_topic", gps_topic_, "navsat_compat/fix");
-  nh_private_.param<std::string>("vel_topic", vel_topic_, "navsat_compat/vel");
+  nh_private_.param<std::string>("gps_topic", gnss_fix_topic_, "navsat_compat/fix");
+  nh_private_.param<std::string>("vel_topic", gnss_vel_topic_, "navsat_compat/vel");
   nh_private_.param<std::string>("imu_topic", imu_topic_, "imu/data");
   nh_private_.param<std::string>("baro_topic", baro_topic_, "baro");
   nh_private_.param<std::string>("airspeed_topic", airspeed_topic_, "airspeed");
@@ -25,8 +25,8 @@ estimator_base::estimator_base():
   nh_private_.param<double>("sigma_Vg_gps", params_.sigma_Vg_gps, 0.0500);
   nh_private_.param<double>("sigma_couse_gps", params_.sigma_course_gps, 0.0045);
 
-  nav_sat_fix_sub_ = nh_.subscribe(gps_topic_, 10, &estimator_base::navSatFixCallback, this);
-  twist_stamped_sub_ = nh_.subscribe(vel_topic_, 10, &estimator_base::twistStampedCallback, this);
+  gnss_fix_sub_ = nh_.subscribe(gnss_fix_topic_, 10, &estimator_base::gnssFixCallback, this);
+  gnss_vel_sub_ = nh_.subscribe(gnss_vel_topic_, 10, &estimator_base::gnssVelCallback, this);
   imu_sub_ = nh_.subscribe(imu_topic_, 10, &estimator_base::imuCallback, this);
   baro_sub_ = nh_.subscribe(baro_topic_, 10, &estimator_base::baroAltCallback, this);
   airspeed_sub_ = nh_.subscribe(airspeed_topic_, 10, &estimator_base::airspeedCallback, this);
@@ -95,7 +95,7 @@ void estimator_base::update(const ros::TimerEvent &)
   vehicle_state_pub_.publish(msg);
 }
 
-void estimator_base::navSatFixCallback(const sensor_msgs::NavSatFix &msg)
+void estimator_base::gnssFixCallback(const sensor_msgs::NavSatFix &msg)
 {
   bool has_fix = msg.status.status >= sensor_msgs::NavSatStatus::STATUS_FIX; // Higher values refer to augmented fixes
   if (!has_fix || !std::isfinite(msg.latitude))
@@ -118,13 +118,13 @@ void estimator_base::navSatFixCallback(const sensor_msgs::NavSatFix &msg)
     input_.gps_new = true;
   }
 }
-void estimator_base::twistStampedCallback(const geometry_msgs::TwistStamped &msg)
+void estimator_base::gnssVelCallback(const geometry_msgs::TwistStamped &msg)
 {
   double v_n = msg.twist.linear.x;
   double v_e = msg.twist.linear.y;
   double v_d = msg.twist.linear.z;
   double ground_speed = sqrt(v_n * v_n + v_e * v_e);
-  double course = atan2(v_e, v_n); //TODO check this math. Also, degrees or radians. From North, right? What range?
+  double course = atan2(v_e, v_n); //Does this need to be in a specific range? All uses seem to accept anything.
   input_.gps_Vg = ground_speed;
   if(ground_speed > 0.3) //this is a magic number. What is it determined from?
     input_.gps_course = course;

--- a/rosplane/src/estimator_base.cpp
+++ b/rosplane/src/estimator_base.cpp
@@ -26,7 +26,7 @@ estimator_base::estimator_base():
   nh_private_.param<double>("sigma_couse_gps", params_.sigma_course_gps, 0.0045);
 
   nav_sat_fix_sub_ = nh_.subscribe(gps_topic_, 10, &estimator_base::navSatFixCallback, this);
-  twist_stamped_sub_ = nh_.subscribe(gps_topic_, 10, &estimator_base::twistStampedCallback, this);
+  twist_stamped_sub_ = nh_.subscribe(vel_topic_, 10, &estimator_base::twistStampedCallback, this);
   imu_sub_ = nh_.subscribe(imu_topic_, 10, &estimator_base::imuCallback, this);
   baro_sub_ = nh_.subscribe(baro_topic_, 10, &estimator_base::baroAltCallback, this);
   airspeed_sub_ = nh_.subscribe(airspeed_topic_, 10, &estimator_base::airspeedCallback, this);

--- a/rosplane/src/estimator_base.cpp
+++ b/rosplane/src/estimator_base.cpp
@@ -115,9 +115,6 @@ void estimator_base::navSatFixCallback(const sensor_msgs::NavSatFix &msg)
     input_.gps_n = EARTH_RADIUS*(msg.latitude - init_lat_)*M_PI/180.0;
     input_.gps_e = EARTH_RADIUS*cos(init_lat_*M_PI/180.0)*(msg.longitude - init_lon_)*M_PI/180.0;
     input_.gps_h = msg.altitude - init_alt_;
-    input_.gps_Vg = msg.speed;
-    if (msg.speed > 0.3) // Magic number?
-      input_.gps_course = msg.ground_course;
     input_.gps_new = true;
   }
 }
@@ -128,7 +125,9 @@ void estimator_base::twistStampedCallback(const geometry_msgs::TwistStamped &msg
   double v_d = msg.twist.linear.z;
   double ground_speed = sqrt(v_n * v_n + v_e * v_e);
   double course = atan2(v_n, -v_e); //TODO check this math. Also, degrees or radians. From North, right? What range?
-  //TODO finish this function
+  input_.gps_Vg = ground_speed;
+  if(ground_speed > 0.3) //this is a magic number. What is it determined from?
+    input_.gps_course = course;
 }
 
 void estimator_base::imuCallback(const sensor_msgs::Imu &msg)

--- a/rosplane/src/estimator_base.cpp
+++ b/rosplane/src/estimator_base.cpp
@@ -124,7 +124,7 @@ void estimator_base::twistStampedCallback(const geometry_msgs::TwistStamped &msg
   double v_e = msg.twist.linear.y;
   double v_d = msg.twist.linear.z;
   double ground_speed = sqrt(v_n * v_n + v_e * v_e);
-  double course = atan2(v_n, -v_e); //TODO check this math. Also, degrees or radians. From North, right? What range?
+  double course = atan2(v_e, v_n); //TODO check this math. Also, degrees or radians. From North, right? What range?
   input_.gps_Vg = ground_speed;
   if(ground_speed > 0.3) //this is a magic number. What is it determined from?
     input_.gps_course = course;


### PR DESCRIPTION
Added support for the new GNSS message formats used by ROSflight. This now uses NavSatFix and TwistStamped messages, but the logic of the estimator is unchanged.
This is tested in simulation and works.